### PR TITLE
Fix name format and stage url uniqueness

### DIFF
--- a/src/run_tests.py
+++ b/src/run_tests.py
@@ -20,7 +20,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
 from test_scraper import ScraperTestFramework
-from async_scraper import ScrapingConfig
+from improved_async_scraper import ScrapingConfig
 
 async def main():
     """Run the test framework"""


### PR DESCRIPTION
Adds tests and fixes for consistent rider name formatting and stable stage ID assignment.

Previously, rider names were sometimes stored as "LastFirst" (e.g., "SaganPeter") instead of "First Last". Additionally, the `javascript_aware_scraper` used `INSERT OR REPLACE` for stages, which caused `stage_ids` to change on subsequent saves of the same `stage_url`, leading to data integrity issues. This PR introduces a `format_rider_name` utility and modifies the stage saving logic to update existing records, preserving `stage_ids`. New tests are added to enforce these behaviors.

---
<a href="https://cursor.com/background-agent?bcId=bc-0768666b-10db-4c7e-8b85-9a41925813fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0768666b-10db-4c7e-8b85-9a41925813fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

